### PR TITLE
Store argument defaults for embedding functions in closures.

### DIFF
--- a/tests/testthat/_snaps/store.md
+++ b/tests/testthat/_snaps/store.md
@@ -1,0 +1,33 @@
+# embed functions get the defaults stored
+
+    Code
+      store@embed
+    Output
+      function (x) 
+      ragnar::embed_openai(x = x, model = "text-embedding-3-small", 
+          base_url = "https://api.openai.com/v1", api_key = get_envvar("OPENAI_API_KEY"), 
+          dims = NULL, user = get_ragnar_username(), batch_size = 20L)
+      <environment: base>
+
+---
+
+    Code
+      store@embed
+    Output
+      function (x) 
+      ragnar::embed_openai(x = x, model = "text-embedding-3-small", 
+          base_url = "https://api.openai.com/v1", api_key = get_envvar("OPENAI_API_KEY"), 
+          dims = NULL, user = get_ragnar_username(), batch_size = 20L)
+      <environment: base>
+
+---
+
+    Code
+      store@embed
+    Output
+      function (x) 
+      ragnar::embed_openai(x = x, model = "text-embedding-3-small", 
+          base_url = "https://api.openai.com/v1", api_key = get_envvar("OPENAI_API_KEY"), 
+          dims = NULL, user = get_ragnar_username(), batch_size = 20L)
+      <environment: base>
+

--- a/tests/testthat/_snaps/store.md
+++ b/tests/testthat/_snaps/store.md
@@ -4,9 +4,7 @@
       store@embed
     Output
       function (x) 
-      ragnar::embed_openai(x = x, model = "text-embedding-3-small", 
-          base_url = "https://api.openai.com/v1", api_key = get_envvar("OPENAI_API_KEY"), 
-          dims = NULL, user = get_ragnar_username(), batch_size = 20L)
+      ragnar::embed_openai(x = x, model = "text-embedding-3-small")
       <environment: base>
 
 ---
@@ -15,9 +13,16 @@
       store@embed
     Output
       function (x) 
-      ragnar::embed_openai(x = x, model = "text-embedding-3-small", 
-          base_url = "https://api.openai.com/v1", api_key = get_envvar("OPENAI_API_KEY"), 
-          dims = NULL, user = get_ragnar_username(), batch_size = 20L)
+      ragnar::embed_openai(x = x, model = "text-embedding-3-small")
+      <environment: base>
+
+---
+
+    Code
+      store@embed
+    Output
+      function (x, ...) 
+      ragnar::embed_openai(x = x, ..., model = "text-embedding-3-small")
       <environment: base>
 
 ---
@@ -26,8 +31,15 @@
       store@embed
     Output
       function (x) 
-      ragnar::embed_openai(x = x, model = "text-embedding-3-small", 
-          base_url = "https://api.openai.com/v1", api_key = get_envvar("OPENAI_API_KEY"), 
-          dims = NULL, user = get_ragnar_username(), batch_size = 20L)
+      ragnar::embed_openai(x = x, model = "text-embedding-3-small")
+      <environment: base>
+
+---
+
+    Code
+      store@embed
+    Output
+      function (x) 
+      ragnar::embed_ollama(x = x, model = "all-minilm")
       <environment: base>
 

--- a/tests/testthat/test-store.R
+++ b/tests/testthat/test-store.R
@@ -198,3 +198,16 @@ test_that("works with MotherDuck", {
   val <- dbGetQuery(store@.con, "select origin, hash, text from chunks")
   expect_equal(nrow(val), 1)
 })
+
+test_that("embed functions get the defaults stored", {
+  store <- ragnar_store_create(embed = function(x) ragnar::embed_openai(x))
+  expect_snapshot(store@embed)
+
+  # here embed_openai is implicitly obtained from ragnar::embed_openai
+  store <- ragnar_store_create(embed = function(x) embed_openai(x))
+  expect_snapshot(store@embed)
+
+  # when using the partialized version, we should also add the defaults
+  store <- ragnar_store_create(embed = embed_openai())
+  expect_snapshot(store@embed)
+})

--- a/tests/testthat/test-store.R
+++ b/tests/testthat/test-store.R
@@ -168,7 +168,6 @@ test_that("Allow a NULL embedding function", {
 })
 
 test_that("works with MotherDuck", {
-
   testthat::skip_if(Sys.getenv("motherduck_token", "") == "")
 
   store <- ragnar_store_create(
@@ -184,7 +183,10 @@ test_that("works with MotherDuck", {
   )
 
   expect_error(ragnar_store_insert(store, chunks), regexp = NA)
-  expect_warning(ragnar_store_build_index(store), regexp = "MotherDuck does not support")
+  expect_warning(
+    ragnar_store_build_index(store),
+    regexp = "MotherDuck does not support"
+  )
   expect_error(ragnar_retrieve(store, "hello"), regexp = NA)
 
   # Since we used insert, there's no checking if the hash is the same
@@ -207,7 +209,17 @@ test_that("embed functions get the defaults stored", {
   store <- ragnar_store_create(embed = function(x) embed_openai(x))
   expect_snapshot(store@embed)
 
+  # if the embed function takes ..., they're preserved
+  store <- ragnar_store_create(
+    embed = function(x, ...) ragnar::embed_openai(x, ...)
+  )
+  expect_snapshot(store@embed)
+
   # when using the partialized version, we should also add the defaults
   store <- ragnar_store_create(embed = embed_openai())
+  expect_snapshot(store@embed)
+
+  # test other embed funcs
+  store <- ragnar_store_create(embed = function(x) ragnar::embed_ollama(x))
   expect_snapshot(store@embed)
 })


### PR DESCRIPTION
This allows us to modify the defaults for the exported embedding functions without breaking stores that are already setup.
Eg, now since the default model is stored in the call, even if we later change the default, previously created stores will continue using the correct model.