### PR TITLE
Include info strings in converted markdown chunks

### DIFF
--- a/R/read-markdown.R
+++ b/R/read-markdown.R
@@ -1,12 +1,11 @@
-#' Convert files to markdown
+#' Convert files to Markdown
 #'
-#' @param x A filepath or URL. Accepts a wide variety of file types, including
-#'   PDF, PowerPoint, Word, Excel, images (EXIF metadata and OCR), audio (EXIF
-#'   metadata and speech transcription), HTML, text-based formats (CSV, JSON,
-#'   XML), ZIP files (iterates over contents), YouTube URLs, and EPUBs.
+#' @param path [string] A filepath or URL. Accepts a wide variety of file types,
+#'   including PDF, PowerPoint, Word, Excel, images (EXIF metadata and OCR),
+#'   audio (EXIF metadata and speech transcription), HTML, text-based formats
+#'   (CSV, JSON, XML), ZIP files (iterates over contents), YouTube URLs, and
+#'   EPUBs.
 #' @param ... Passed on to `MarkItDown.convert()`.
-#' @param canonical Logical. Whether to postprocess the output from MarkItDown
-#'   with `commonmark::markdown_commonmark()`.
 #' @param html_extract_selectors Character vector of CSS selectors. If a match
 #'   for a selector is found in the document, only the matched node's contents
 #'   are converted. Unmatched extract selectors have no effect.
@@ -16,7 +15,7 @@
 #'   sidebars, headers, footers, or other unwanted elements. By default,
 #'   navigation elements (`nav`) are excluded.
 #'
-#' @returns A single string of markdown.
+#' @returns A single string of Markdown.
 #' @export
 #'
 #' @examplesIf reticulate::py_available()
@@ -120,45 +119,43 @@
 #'   chat$chat("Describe this image", ellmer::content_image_file(jpg))
 #' }
 read_as_markdown <- function(
-  x,
+  path,
   ...,
-  canonical = FALSE,
   html_extract_selectors = c("main"),
   html_zap_selectors = c("nav")
 ) {
-  check_string(x)
-  if (startsWith(x, "~")) {
+  check_string(path)
+  if (startsWith(path, "~")) {
     x <- path.expand(x)
   }
 
   if (getOption("ragnar.markitdown.use_reticulate", TRUE)) {
-    # use the Python API, faster, more powerful, the default
+    # use the Python API, faster, more powerful, the default,
     # but we leave an escape hatch just in case there are other python
     # dependencies that conflict
     md <- ragnartools.markitdown$convert_to_markdown(
-      x,
+      path,
       html_extract_selectors = html_extract_selectors,
       html_zap_selectors = html_zap_selectors,
       ...,
     )
   } else {
-    md <- read_as_markdown_cli(x, ...)
+    md <- read_as_markdown_cli(path, ...)
   }
 
-  md <- stri_replace_all_fixed(md, "\f", "\n\n---\n\n")
-  md <- unlist(stri_split_lines(md)) # normalize newlines
-  md <- stri_trim_right(md)
-  if (canonical) {
-    md <- commonmark::markdown_commonmark(
-      md,
+  # normalize
+  md |>
+    stri_split_lines() |>
+    unlist() |>
+    enc2utf8() |>
+    stri_trim_right() |>
+    stri_flatten("\n") |>
+    commonmark::markdown_commonmark(
       normalize = TRUE,
       footnotes = TRUE,
-      width = 72L,
       extensions = TRUE
-    )
-  }
-  md <- stri_flatten(md, "\n")
-  glue::as_glue(md)
+    ) |>
+    as_glue()
 }
 
 

--- a/inst/python/_ragnartools/markitdown.py
+++ b/inst/python/_ragnartools/markitdown.py
@@ -1,7 +1,43 @@
+import re
 import markitdown
 from markitdown.converters._markdownify import _CustomMarkdownify
 
 md = markitdown.MarkItDown()
+
+
+def maybe_insert_info_string(text, class_):
+    """
+    Insert the desired info-string (`class_`) after the first code fence if it
+    is not already present.
+    """
+    if not class_:
+        return text
+    if isinstance(class_, list):
+        try:
+            class_ = class_[class_.index("sourceCode") + 1]
+        except:
+            class_ = " ".join(class_)
+
+    class_ = str(class_).strip()
+    if not class_:
+        return text
+
+    # find the first code fence
+    m = re.match(r"^(\s*)(`{3,})([^\n]*)", text)
+    if not m:  # no code fence
+        return text
+
+    indent, fence, info = m.groups()
+    info_tokens = info.strip().split()
+    class_tokens = class_.split()
+
+    # add only the missing tokens from `class_`
+    missing = [t for t in class_tokens if t not in info_tokens]
+    if not missing:  # already present
+        return text
+
+    new_info = " ".join(info_tokens + missing).strip()
+    return f"{indent}{fence}{new_info}{text[m.end() :]}"
 
 
 def maybe_expand_outer_code_fence(text):
@@ -55,10 +91,8 @@ class patched_markitdown:
         self.og_convert_soup = og_convert_soup = _CustomMarkdownify.convert_soup
 
         def convert_soup(self_, soup):
-
             for selector in self.html_extract_selectors:
                 if (tag := soup.select_one(selector)) is not None:
-
                     soup = tag.extract()
 
             for selector in self.html_zap_selectors:
@@ -71,9 +105,12 @@ class patched_markitdown:
 
         self.og_convert_pre = og_convert_pre = _CustomMarkdownify.convert_pre
 
-        def convert_pre(self, el, text, parent_tags):
-            text = og_convert_pre(self, el, text, parent_tags)
-            return maybe_expand_outer_code_fence(text)
+        def convert_pre(self_, el, text, parent_tags):
+            class_ = el.get("class", [])
+            text = og_convert_pre(self_, el, text, parent_tags)
+            text = maybe_expand_outer_code_fence(text)
+            text = maybe_insert_info_string(text, class_)
+            return text
 
         _CustomMarkdownify.convert_pre = convert_pre
 
@@ -120,7 +157,7 @@ def convert_to_markdown(
             title = f"# {result.title}"
             if not text.startswith(title):
                 text = f"{title}\n\n{text}"
-                
+
         text = text.replace("\f", "\n\n---\n\n")
 
         return text

--- a/man/read_as_markdown.Rd
+++ b/man/read_as_markdown.Rd
@@ -2,26 +2,23 @@
 % Please edit documentation in R/read-markdown.R
 \name{read_as_markdown}
 \alias{read_as_markdown}
-\title{Convert files to markdown}
+\title{Convert files to Markdown}
 \usage{
 read_as_markdown(
-  x,
+  path,
   ...,
-  canonical = FALSE,
   html_extract_selectors = c("main"),
   html_zap_selectors = c("nav")
 )
 }
 \arguments{
-\item{x}{A filepath or URL. Accepts a wide variety of file types, including
-PDF, PowerPoint, Word, Excel, images (EXIF metadata and OCR), audio (EXIF
-metadata and speech transcription), HTML, text-based formats (CSV, JSON,
-XML), ZIP files (iterates over contents), YouTube URLs, and EPUBs.}
+\item{path}{\link{string} A filepath or URL. Accepts a wide variety of file types,
+including PDF, PowerPoint, Word, Excel, images (EXIF metadata and OCR),
+audio (EXIF metadata and speech transcription), HTML, text-based formats
+(CSV, JSON, XML), ZIP files (iterates over contents), YouTube URLs, and
+EPUBs.}
 
 \item{...}{Passed on to \code{MarkItDown.convert()}.}
-
-\item{canonical}{Logical. Whether to postprocess the output from MarkItDown
-with \code{commonmark::markdown_commonmark()}.}
 
 \item{html_extract_selectors}{Character vector of CSS selectors. If a match
 for a selector is found in the document, only the matched node's contents
@@ -34,10 +31,10 @@ sidebars, headers, footers, or other unwanted elements. By default,
 navigation elements (\code{nav}) are excluded.}
 }
 \value{
-A single string of markdown.
+A single string of Markdown.
 }
 \description{
-Convert files to markdown
+Convert files to Markdown
 }
 \examples{
 \dontshow{if (reticulate::py_available()) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}


### PR DESCRIPTION
With this PR, html converted to markdown via `read_as_markdown()` will now make a best effort to include info strings with the code chunk.

For example: 

```r
read_as_markdown("https://quarto.org/docs/computations/r.html")
```
will now label code chunks with the language, like this

`````markdown
## Caching

The [Knitr Cache](https://bookdown.org/yihui/rmarkdown-cookbook/cache.html) operates at the level of individual cells rather than the entire document. While this can be very convenient, it also introduced some special requirements around managing the dependencies between cells.

You can enable the Knitr cache at the document or project level using standard YAML options:

``` yaml
---
title: "My Document"
format: html
execute:
  cache: true
---
```

You can also enable caching on a per-cell basis (in this you would *not* set the document level option):

```` markdown
```{r}
#| cache: true

summary(cars)
```
````

