### PR TITLE
Small fixes to Store V2

### DIFF
--- a/R/retrieve.R
+++ b/R/retrieve.R
@@ -108,6 +108,7 @@ ragnar_retrieve_vss <- function(
         LIMIT {top_k}
       ) AS e
       JOIN documents doc USING (origin)
+      ORDER BY metric_value
       "
     ))
     # check_hnsw_index_scan_used(con, sql_query)
@@ -154,6 +155,7 @@ ragnar_retrieve_vss <- function(
       LIMIT 5000
     ) AS e
     JOIN documents doc USING (origin)
+    ORDER BY metric_value
     "
   ))
 

--- a/R/store-v2.R
+++ b/R/store-v2.R
@@ -292,7 +292,6 @@ ragnar_store_update_v2 <- function(store, chunks) {
 
 
 ragnar_store_insert_v2 <- function(store, chunks, replace_existing = FALSE) {
-  browser()
   if (!S7_inherits(chunks, MarkdownDocumentChunks)) {
     stop(glue::trim(
       "Invalid input for store. `store@version == 2`, but input provided is store version 1.,

--- a/tests/testthat/helper-doc.R
+++ b/tests/testthat/helper-doc.R
@@ -18,3 +18,5 @@ maybe_set_threads <- function(store) {
   }
   store
 }
+
+as_bare_df <- function(x) as.data.frame(as.list(x))

--- a/tests/testthat/test-read-markdown.R
+++ b/tests/testthat/test-read-markdown.R
@@ -16,10 +16,12 @@ test_that("ragnar_read() empty doc", {
 
 test_that("ragnar_read() doc in ~", {
   withr::with_tempfile("tilde_file", tmpdir = "~", fileext = ".md", {
-    file.copy(system.file("store-inspector","README.md", package = "ragnar"), tilde_file)
+    file.copy(
+      system.file("store-inspector", "README.md", package = "ragnar"),
+      tilde_file
+    )
     expect_no_error(ragnar_read(tilde_file))
   })
-
 })
 
 

--- a/tests/testthat/test-retrieve.R
+++ b/tests/testthat/test-retrieve.R
@@ -1,4 +1,4 @@
-test_that("retrieving works as expected", {
+test_that("retrieving works as expected, v1", {
   # Create a simple store and insert some chunks
   store <- ragnar_store_create(
     version = 1,
@@ -25,6 +25,59 @@ test_that("retrieving works as expected", {
   # test edge case where top_k is larger than the number of entries
   # in the store
   ret <- ragnar_retrieve_vss(store, "hello", top_k = 10)
+  expect_equal(nrow(ret), 3)
+
+  # Can retrieve with bm25
+  ret <- ragnar_retrieve_bm25(store, "foo")
+  expect_in("metric_value", names(ret))
+  expect_in("metric_name", names(ret))
+  expect_equal(nrow(ret), 1)
+  # Expect that all columns from the schema (except for embedding)
+  # to be in the result set
+  expect_true(all(
+    setdiff(names(store@schema), "embedding") %in% names(ret)
+  ))
+
+  # Can retrieve using the combined method
+  ret <- ragnar_retrieve_vss_and_bm25(store, "foo")
+  expect_equal(nrow(ret), 3)
+
+  # Can retrieve using ragnar_retrieve
+  ret <- ragnar_retrieve(store, "foo")
+  expect_equal(nrow(ret), 3)
+})
+
+
+test_that("retrieving works as expected", {
+  # Create a simple store and insert some chunks
+  store <- ragnar_store_create(
+    embed = \(x) matrix(nrow = length(x), ncol = 100, stats::runif(100))
+  )
+  maybe_set_threads(store)
+
+  # path <- system.file("README.md", package = "ragnar")
+  # doc <- MarkdownDocument(readLines(path), path)
+  doc <- MarkdownDocument(c("foo", "bar", "faz"), 'someorigin')
+  chunks <- doc |> markdown_chunk(target_size = 4, target_overlap = 0)
+  ragnar_store_insert(store, chunks)
+  ragnar_store_build_index(store)
+
+  # Can retrieve with vss
+  ret <- ragnar_retrieve_vss(store, "hello")
+  expect_in(
+    c("origin", "id", "start", "end", "text", "metric_value", "metric_value"),
+    names(ret)
+  )
+  expect_equal(nrow(ret), 3)
+  # Expect that all columns from the schema (except for embedding)
+  # to be in the result set
+  expect_true(all(
+    setdiff(names(store@schema), "embedding") %in% names(ret)
+  ))
+
+  # test edge case where top_k is larger than the number of entries
+  # in the store
+  ret <- ragnar_retrieve_vss(store, "hello", top_k = 100)
   expect_equal(nrow(ret), 3)
 
   # Can retrieve with bm25


### PR DESCRIPTION
Followup to #61 with some minor adjustments and fixes.

- fixes for store created with `embed = NULL`
- ensure `ragnar_retrieve_vss()` always orders by metric (apparently a left join in duckdb does not preserve the left table order)
- add tests
- fix unactionable error messages from `dbWithTransaction()`, as seen in https://github.com/tidyverse/ragnar/pull/61#issuecomment-3047132482