### PR TITLE
Disable converting to canonical markdown

### DIFF
--- a/R/ellmer.R
+++ b/R/ellmer.R
@@ -14,7 +14,6 @@
 #' @export
 #'
 #' @examplesIf (file.exists("r4ds.ragnar.duckdb") && Sys.getenv("OPENAI_API_KEY") != "")
-#'
 #' system_prompt <- stringr::str_squish("
 #'   You are an expert assistant in R programming.
 #'   When responding, you first quote relevant material from books or documentation,
@@ -22,7 +21,7 @@
 #' ")
 #' chat <- ellmer::chat_openai(system_prompt, model = "gpt-4o")
 #'
-#' store <- ragnar_store_connect("r4ds.ragnar.duckdb", read_only = TRUE)
+#' store <- ragnar_store_connect("r4ds.ragnar.duckdb")
 #' ragnar_register_tool_retrieve(chat, store)
 #' chat$chat("How can I subset a dataframe?")
 ragnar_register_tool_retrieve <- function(

--- a/R/legacy.R
+++ b/R/legacy.R
@@ -1,8 +1,12 @@
 #' Read a document as Markdown
 #'
+#' @description
+#'
 #' `r lifecycle::badge("deprecated")`
 #'
 #' This function is deprecated in favor of `read_as_markdown()`.
+#'
+#' @details
 #'
 #' `ragnar_read()` uses [markitdown](https://github.com/microsoft/markitdown) to
 #' convert a document to markdown. If `frame_by_tags` or `split_by_tags` is
@@ -139,6 +143,8 @@ ragnar_read <- function(x, ..., split_by_tags = NULL, frame_by_tags = NULL) {
 
 #' Chunk text
 #'
+#' @description
+#'
 #' `r lifecycle::badge("deprecated")`
 #'
 #' These functions are deprecated in favor of `markdown_chunk()`, which is more
@@ -146,6 +152,8 @@ ragnar_read <- function(x, ..., split_by_tags = NULL, frame_by_tags = NULL) {
 #' downstream by `ragnar_retrieve()`, and automatically builds a `context`
 #' string of in-scope markdown headings for each chunk instead of requiring
 #' manual string interpolation from extracted headings.
+#'
+#' @details
 #'
 #' Functions for chunking text into smaller pieces while preserving meaningful
 #' semantics. These functions provide flexible ways to split text based on

--- a/R/markdown-chunk.R
+++ b/R/markdown-chunk.R
@@ -262,7 +262,7 @@ markdown_node_positions <- function(md, type = NULL, text = FALSE) {
     df$text <- stri_sub(md, df$start, df$end)
   }
 
-  df
+  df |> arrange(start, end)
 }
 
 str_locate_boundary_starts1 <- function(string, type) {

--- a/R/markdown-chunk.R
+++ b/R/markdown-chunk.R
@@ -1,10 +1,10 @@
 #' Chunk a Markdown document
 #'
-#' `markdown_chunk()` splits a single Markdown string into fixed-length,
+#' `markdown_chunk()` splits a single Markdown string into shorter
 #' optionally overlapping chunks while nudging cut points to the nearest
 #' sensible boundary (heading, paragraph, sentence, line, word, or character).
-#' It returns a tibble recording the character ranges of each chunk and, if
-#' requested, the heading context and the text itself.
+#' It returns a tibble recording the character ranges, headings context, and text
+#' for each chunk.
 #'
 #' @param md A `MarkdownDocument`, or a length-one character vector containing
 #'   Markdown.
@@ -78,8 +78,8 @@ markdown_chunk <- function(
   target_overlap = .5,
   ...,
   max_snap_dist = target_size * (1 - target_overlap) / 3,
-  context = TRUE,
   segment_by_heading_levels = integer(),
+  context = TRUE,
   text = TRUE
 ) {
   # arg checks
@@ -276,7 +276,8 @@ str_locate_boundary_starts1 <- function(string, type) {
 
 
 snap_nearest <- function(x, candidates, max_dist = NULL) {
-  if ((n_candidates <- length(candidates)) == 0L) {
+  n_candidates <- length(candidates)
+  if (n_candidates == 0L) {
     return(rep(NA, length(x)))
   }
   if (n_candidates == 1L) {
@@ -286,13 +287,7 @@ snap_nearest <- function(x, candidates, max_dist = NULL) {
     }
     return(out)
   }
-  left_idx <- findInterval(
-    x,
-    candidates,
-    all.inside = TRUE
-    ## checkSorted and checkNA added in 4.5
-    # , checkSorted = FALSE, checkNA = FALSE
-  )
+  left_idx <- findInterval(x, candidates, all.inside = TRUE)
   right_idx <- left_idx + 1L
 
   left <- candidates[left_idx]

--- a/R/markdown-document.R
+++ b/R/markdown-document.R
@@ -36,18 +36,23 @@ MarkdownDocument := new_class(
   }
 )
 
-markdown_normalize <- function(md) {
-  md |>
+markdown_normalize <- function(md, canonical = FALSE) {
+  md <- md |>
     stri_split_lines() |>
     unlist() |>
     enc2utf8() |>
     stri_trim_right() |>
-    stri_flatten("\n") |>
-    commonmark::markdown_commonmark(
-      normalize = TRUE,
-      footnotes = TRUE,
-      extensions = TRUE
-    )
+    stri_flatten("\n")
+
+  if (canonical) {
+    md <- md |>
+      commonmark::markdown_commonmark(
+        normalize = TRUE,
+        footnotes = TRUE,
+        extensions = TRUE
+      )
+  }
+  md
 }
 
 local({

--- a/R/markdown-document.R
+++ b/R/markdown-document.R
@@ -71,7 +71,7 @@ local({
 #' Markdown document. It is a tibble with three required columns:
 #'
 #' * `start`, `end` — integers. These are character positions (1-based, inclusive) in the source
-#' `MarkdownDocument`, so that `substr(md, start, end)` yields the chunk text.
+#' `MarkdownDocument`, so that `substring(md, start, end)` yields the chunk text.
 #' Ranges can overlap.
 #'
 #' * `context` — character.

--- a/R/markdown-document.R
+++ b/R/markdown-document.R
@@ -3,12 +3,11 @@
 #' @description
 #'
 #' `MarkdownDocument` represents a complete Markdown document stored as a single
-#' character string. The constructor normalizes `text` by flattening lines and
+#' character string. The constructor normalizes `text` by collapsing lines and
 #' ensuring UTF-8 encoding, so downstream code can rely on a consistent format.
 #'
-#' For day-to-day work you almost never need to call the constructor directly:
 #' [`read_as_markdown()`] is the recommended way to create a `MarkdownDocument`.
-#' The class itself is exported only so advanced users can construct one by
+#' The constructor itself is exported only so advanced users can construct one by
 #' other means when needed.
 #'
 #' @param text \[string] Markdown text.
@@ -89,8 +88,8 @@ local({
 #' The original document is available via the `@document` property.
 #'
 #' For normal use, chunk a Markdown document with [`markdown_chunk()`]; the
-#' class itself is exported only so advanced users can generate or tweak chunks
-#' by other means.
+#' class constructor itself is exported only so advanced users can generate or
+#' tweak chunks by other means.
 #'
 #' @param chunks A data frame containing `start`, `end`, and `context` columns,
 #'   and optionally other columns.
@@ -99,13 +98,16 @@ local({
 #' @return An S7 object that inherits from `MarkdownDocumentChunks`, which is
 #'   also a `tibble`.
 #' @export
+#' @seealso [MarkdownDocument()]
 #' @name MarkdownDocumentChunks
 #' @examples
-#' doc <- MarkdownDocument("# A\n\nB\n\n## C\n\nD")
+#' doc_text <- "# A\n\nB\n\n## C\n\nD"
+#' doc <- MarkdownDocument(doc_text, origin = "some/where")
 #' chunk_positions <- tibble::tibble(
-#'   start    = c(1L, 5L),
-#'   end      = c(3L, 7L),
-#'   context = c("A", "A\nC")
+#'   start = c(1L, 9L),
+#'   end = c(8L, 15L),
+#'   context = c("", "# A"),
+#'   text = substring(doc, start, end)
 #' )
 #' chunks <- MarkdownDocumentChunks(chunk_positions, doc)
 #' identical(chunks@document, doc)

--- a/R/markdown-document.R
+++ b/R/markdown-document.R
@@ -1,9 +1,10 @@
 #' Markdown documents
 #'
-#' @description `MarkdownDocument` represents a complete Markdown document
-#' stored as a single character string.  The constructor normalises the text
-#' with `commonmark::markdown_commonmark()` so downstream code can rely on a
-#' consistent format.
+#' @description
+#'
+#' `MarkdownDocument` represents a complete Markdown document stored as a single
+#' character string. The constructor normalizes `text` by flattening lines and
+#' ensuring UTF-8 encoding, so downstream code can rely on a consistent format.
 #'
 #' For day-to-day work you almost never need to call the constructor directly:
 #' [`read_as_markdown()`] is the recommended way to create a `MarkdownDocument`.
@@ -12,10 +13,10 @@
 #'
 #' @param text \[string] Markdown text.
 #' @param origin \[string] Optional source path or URL. Defaults to the
-#'   `"origin"` attribute of `text`, if present, otherwise `NA`.
+#'   `"origin"` attribute of `text`, if present, otherwise `NULL`.
 #'
 #' @return An S7 object that inherits from `MarkdownDocument`, which is a length
-#'   1 string of markdown text and an `@origin` property.
+#'   1 string of markdown text with an `@origin` property.
 #' @export
 #'
 #' @name MarkdownDocument

--- a/R/markdown-document.R
+++ b/R/markdown-document.R
@@ -71,8 +71,8 @@ local({
 #' Markdown document. It is a tibble with three required columns:
 #'
 #' * `start`, `end` — integers. These are character positions (1-based, inclusive) in the source
-#' `MarkdownDocument`, so that `substring(md, start, end)` yields the chunk text.
-#' Ranges can overlap.
+#' `MarkdownDocument`, so that `substring(md, start, end)` yields the chunk
+#' text. Ranges can overlap.
 #'
 #' * `context` — character.
 #' A general-purpose field for adding context to a chunk. This column is

--- a/R/read-markdown.R
+++ b/R/read-markdown.R
@@ -42,46 +42,34 @@
 #' md <- read_as_markdown("https://r4ds.hadley.nz/base-R.html")
 #' md
 #'
-#' cat(substr(md, 1, 500))
+#' cat_head <- \(md, n = 10) writeLines(head(strsplit(md, "\n")[[1L]], n))
+#' cat_head(md)
 #'
 #' ## Using selector strings
 #'
+#' # By default, this output includes the sidebar and other navigational elements
 #' url <- "https://duckdb.org/code_of_conduct"
-#' # Includes the sidebar and other navigational elements
-#' read_as_markdown(url) |> substr(1, 500) |> writeLines()
+#' read_as_markdown(url) |> cat_head(15)
 #'
-#' # Extract the main content
-#' read_as_markdown(url, html_extract_selectors = "#main_content_wrap")
+#' # To extract just the main content, use a selector
+#' read_as_markdown(url, html_extract_selectors = "#main_content_wrap") |>
+#'   cat_head()
 #'
-#' # Alternative approach: exclude nodes
+#' # Alternative approach: zap unwanted nodes
 #' read_as_markdown(
 #'   url,
 #'   html_zap_selectors = c(
-#'     "header",          # node name
-#'     ".sidenavigation", # node class
-#'     ".searchoverlay",  # node class
-#'     "#sidebar"         # node ID
+#'     "header",          # name
+#'     ".sidenavigation", # class
+#'     ".searchoverlay",  # class
+#'     "#sidebar"         # ID
 #'   )
-#' ) |> substr(1, 500) |> writeLines()
+#' ) |> cat_head()
 #'
 #' # Quarto example
-#' url <- "https://quarto.org/docs/computations/python.html"
-#'
-#' # Include sidebar, footer, etc.
 #' read_as_markdown(
-#'   url,
-#'   html_extract_selectors = NULL,
-#'   html_zap_selectors = NULL
-#' ) |> substr(1, 500) |> writeLines()
-#'
-#' # Exclude content outside <main>
-#' read_as_markdown(url, html_extract_selectors = "main") |>
-#'   substr(1, 500) |> writeLines()
-#'
-#' # Exclude specific matching nodes
-#' read_as_markdown(
-#'   url,
-#'   html_extract_selectors = NULL,
+#'   "https://quarto.org/docs/computations/python.html",
+#'   html_extract_selectors = "main",
 #'   html_zap_selectors = c(
 #'     "#quarto-sidebar",
 #'     "#quarto-margin-sidebar",
@@ -89,13 +77,13 @@
 #'     "footer",
 #'     "nav"
 #'   )
-#' ) |> substr(1, 500) |> writeLines()
+#' ) |> cat_head()
 #'
-#' # Convert PDF
+#' ## Convert PDF
 #' pdf <- file.path(R.home("doc"), "NEWS.pdf")
-#' read_as_markdown(pdf) |> substr(1, 1000) |> cat()
+#' read_as_markdown(pdf) |> cat_head(15)
 #' ## Alternative:
-#' # pdftools::pdf_text(pdf) |> substr(1, 2000) |> cat()
+#' # pdftools::pdf_text(pdf) |> cat_head()
 #'
 #' # Convert images to markdown descriptions using OpenAI
 #' jpg <- file.path(R.home("doc"), "html", "logo.jpg")
@@ -103,7 +91,8 @@
 #'   # if (xfun::is_macos()) system("brew install ffmpeg")
 #'   reticulate::py_require("openai")
 #'   llm_client <- reticulate::import("openai")$OpenAI()
-#'   read_as_markdown(jpg, llm_client = llm_client, llm_model = "gpt-4.1-mini")
+#'   read_as_markdown(jpg, llm_client = llm_client, llm_model = "gpt-4.1-mini") |>
+#'     writeLines()
 #'   # # Description:
 #'   # The image displays the logo of the R programming language. It features a
 #'   # large, stylized capital letter "R" in blue, positioned prominently in the

--- a/R/read-markdown.R
+++ b/R/read-markdown.R
@@ -144,7 +144,7 @@ read_as_markdown <- function(
     md <- read_as_markdown_cli(path, ...)
   }
 
-  MarkdownDocument(md, origin = origin)
+  MarkdownDocument(md, origin)
 }
 
 

--- a/R/read-markdown.R
+++ b/R/read-markdown.R
@@ -1,10 +1,10 @@
 #' Convert files to Markdown
 #'
-#' @param path \[string\] A filepath or URL. Accepts a wide variety of file types,
-#'   including PDF, PowerPoint, Word, Excel, images (EXIF metadata and OCR),
-#'   audio (EXIF metadata and speech transcription), HTML, text-based formats
-#'   (CSV, JSON, XML), ZIP files (iterates over contents), YouTube URLs, and
-#'   EPUBs.
+#' @param path \[string\] A filepath or URL. Accepts a wide variety of file
+#'   types, including PDF, PowerPoint, Word, Excel, images (EXIF metadata and
+#'   OCR), audio (EXIF metadata and speech transcription), HTML, text-based
+#'   formats (CSV, JSON, XML), ZIP files (iterates over contents), YouTube URLs,
+#'   and EPUBs.
 #' @param ... Passed on to `MarkItDown.convert()`.
 #' @param html_extract_selectors Character vector of CSS selectors. If a match
 #'   for a selector is found in the document, only the matched node's contents
@@ -15,32 +15,36 @@
 #'   sidebars, headers, footers, or other unwanted elements. By default,
 #'   navigation elements (`nav`) are excluded.
 #'
-#' @returns A single string of Markdown.
-#' @export
+#' @details
 #'
+#' ## Converting HTML
+#'
+#' When converting HTML, you might want to omit certain elements, like sidebars,
+#' headers, footers, etc. You can pass CSS selector strings to either extract
+#' nodes or exclude nodes during conversion.
+#'
+#' The easiest way to make selectors is to use SelectorGadget:
+#' <https://rvest.tidyverse.orgarticles/selectorgadget.html>
+#'
+#' You can also right-click on a page and select "Inspect Element" in a browser
+#' to better understand an HTML page's structure.
+#'
+#' For comprehensive or advanced usage of CSS selectors, consult
+#' <https://www.crummy.com/software/BeautifulSoup/bs4/doc/#css-selectors-through-the-css-property>
+#' and <https://facelessuser.github.io/soupsieve/selectors/>
+#'
+#' @returns A single string of Markdown.
+#'
+
+#' @export
 #' @examplesIf reticulate::py_module_available("markitdown")
 #' # Convert HTML
-#' read_as_markdown("https://r4ds.hadley.nz/base-R.html") |>
-#'   substr(1, 500) |>
-#'   cat()
+#' md <- read_as_markdown("https://r4ds.hadley.nz/base-R.html")
+#' md
 #'
-#' read_as_markdown("https://r4ds.hadley.nz/base-R.html", canonical = TRUE) |>
-#'   substr(1, 500) |>
-#'   cat()
+#' cat(substr(md, 1, 500))
 #'
-#' # When converting HTML, you might want to omit certain elements, like
-#' # sidebars, headers, footers, etc. You can pass CSS selector strings
-#' # to either extract nodes or exclude nodes during conversion.
-#' #
-#' # The easiest way to make selectors is to use SelectorGadget:
-#' # https://rvest.tidyverse.orgarticles/selectorgadget.html
-#' #
-#' # You can also right-click on a page and select "Inspect Element" in a
-#' # browser to better understand an HTML page's structure.
-#' #
-#' # For comprehensive or advanced usage of CSS selectors, consult:
-#' # https://www.crummy.com/software/BeautifulSoup/bs4/doc/#css-selectors-through-the-css-property
-#' # https://facelessuser.github.io/soupsieve/selectors/
+#' ## Using selector strings
 #'
 #' url <- "https://duckdb.org/code_of_conduct"
 #' # Includes the sidebar and other navigational elements

--- a/R/store-v1.R
+++ b/R/store-v1.R
@@ -249,7 +249,7 @@ ragnar_store_insert_v1 <- function(store, chunks) {
   }
 
   if (S7::S7_inherits(chunks, MarkdownDocumentChunks)) {
-    chunks <- chunks |> 
+    chunks <- chunks |>
       dplyr::select(dplyr::any_of(names(store@schema)))
     if (is.null(chunks[["origin"]])) {
       chunks$origin <- chunks@document@origin
@@ -293,8 +293,8 @@ ragnar_store_insert_v1 <- function(store, chunks) {
     ))
   }
 
-  chunks <- chunks |> 
-    dplyr::select(dplyr::any_of(names(schema))) |> 
+  chunks <- chunks |>
+    dplyr::select(dplyr::any_of(names(schema))) |>
     vctrs::vec_cast(store@schema)
 
   dbAppendTable(
@@ -368,7 +368,7 @@ dbDataType2 <- function(con, x) {
       # by default.
       dataTypes[[nm]] <- paste0("FLOAT[", ncol(x[[nm]]), "]")
     } else if (is.matrix(x[[nm]])) {
-      dataTypes[[nm]] <- paste0(dataTypes[i], "[", ncol(x[[nm]]), "]")
+      dataTypes[[nm]] <- paste0(dataTypes[nm], "[", ncol(x[[nm]]), "]")
     }
   }
   dataTypes

--- a/R/store.R
+++ b/R/store.R
@@ -64,7 +64,7 @@
 #' ragnar_store_insert(store, data.frame(text = "hello"))
 #'
 #' # A store with a schema. When inserting into this store, users need to
-#' # provide a `area` column.
+#' # provide an `area` column.
 #' store <- ragnar_store_create(
 #'   embed = \(x) matrix(stats::runif(10), nrow = length(x), ncol = 10),
 #'   extra_cols = data.frame(area = character()),
@@ -73,7 +73,7 @@
 #' ragnar_store_insert(store, data.frame(text = "hello", area = "rag"))
 #'
 #' # If you already have a data.frame with chunks that will be inserted into
-#' # the store, you can quickly create a suitable store with:
+#' # the store, you can quickly create a suitable store with `vec_ptype()`:
 #' chunks <- data.frame(text = letters, area = "rag")
 #' store <- ragnar_store_create(
 #'   embed = \(x) matrix(stats::runif(10), nrow = length(x), ncol = 10),
@@ -84,14 +84,19 @@
 #'
 #' # version = 2 (the default) has support for deoverlapping
 #' store <- ragnar_store_create(
-#'   embed = NULL # if embed = NULL, then only bm25 search is used (not vss)
+#'   # if embed = NULL, then only bm25 search is used (not vss)
+#'   embed = NULL
 #' )
-#' doc <- MarkdownDocument(paste0(letters, collapse = ""), origin = "/some/where")
+#' doc <- MarkdownDocument(
+#'   paste0(letters, collapse = ""),
+#'   origin = "/some/where"
+#' )
 #' chunks <- markdown_chunk(doc, target_size = 3, target_overlap = 2 / 3)
 #' chunks$context <- substring(chunks$text, 1, 1)
 #' chunks
 #' ragnar_store_insert(store, chunks)
 #' ragnar_store_build_index(store)
+#'
 #' ragnar_retrieve(store, "abc bcd xyz", deoverlap = FALSE)
 #' ragnar_retrieve(store, "abc bcd xyz", deoverlap = TRUE)
 ragnar_store_create <- function(

--- a/R/store.R
+++ b/R/store.R
@@ -88,7 +88,7 @@
 #' )
 #' doc <- MarkdownDocument(paste0(letters, collapse = ""), origin = "/some/where")
 #' chunks <- markdown_chunk(doc, target_size = 3, target_overlap = 2 / 3)
-#' chunks$context <- substr(chunks$text, 1, 1)
+#' chunks$context <- substring(chunks$text, 1, 1)
 #' chunks
 #' ragnar_store_insert(store, chunks)
 #' ragnar_store_build_index(store)

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -15,9 +15,9 @@ reference:
   - title: Document processing
     desc: Ingest documents from the web, PDFs, Word, or local Markdown.
     contents:
-      - ragnar_find_links
       - read_as_markdown
       - MarkdownDocument
+      - ragnar_find_links
 
       ## store v1
       # - ragnar_read

--- a/man/MarkdownDocument.Rd
+++ b/man/MarkdownDocument.Rd
@@ -4,7 +4,7 @@
 \alias{MarkdownDocument}
 \title{Markdown documents}
 \arguments{
-\item{text}{[string] Character vector of Markdown text.}
+\item{text}{[string] Markdown text.}
 
 \item{origin}{[string] Optional source path or URL. Defaults to the
 \code{"origin"} attribute of \code{text}, if present, otherwise \code{NULL}.}

--- a/man/MarkdownDocument.Rd
+++ b/man/MarkdownDocument.Rd
@@ -4,7 +4,7 @@
 \alias{MarkdownDocument}
 \title{Markdown documents}
 \arguments{
-\item{text}{[string] Markdown text.}
+\item{text}{[string] Character vector of Markdown text.}
 
 \item{origin}{[string] Optional source path or URL. Defaults to the
 \code{"origin"} attribute of \code{text}, if present, otherwise \code{NULL}.}
@@ -15,12 +15,11 @@ An S7 object that inherits from \code{MarkdownDocument}, which is a length
 }
 \description{
 \code{MarkdownDocument} represents a complete Markdown document stored as a single
-character string. The constructor normalizes \code{text} by flattening lines and
+character string. The constructor normalizes \code{text} by collapsing lines and
 ensuring UTF-8 encoding, so downstream code can rely on a consistent format.
 
-For day-to-day work you almost never need to call the constructor directly:
 \code{\link[=read_as_markdown]{read_as_markdown()}} is the recommended way to create a \code{MarkdownDocument}.
-The class itself is exported only so advanced users can construct one by
+The constructor itself is exported only so advanced users can construct one by
 other means when needed.
 }
 \examples{

--- a/man/MarkdownDocument.Rd
+++ b/man/MarkdownDocument.Rd
@@ -7,17 +7,16 @@
 \item{text}{[string] Markdown text.}
 
 \item{origin}{[string] Optional source path or URL. Defaults to the
-\code{"origin"} attribute of \code{text}, if present, otherwise \code{NA}.}
+\code{"origin"} attribute of \code{text}, if present, otherwise \code{NULL}.}
 }
 \value{
 An S7 object that inherits from \code{MarkdownDocument}, which is a length
-1 string of markdown text and an \verb{@origin} property.
+1 string of markdown text with an \verb{@origin} property.
 }
 \description{
-\code{MarkdownDocument} represents a complete Markdown document
-stored as a single character string.  The constructor normalises the text
-with \code{commonmark::markdown_commonmark()} so downstream code can rely on a
-consistent format.
+\code{MarkdownDocument} represents a complete Markdown document stored as a single
+character string. The constructor normalizes \code{text} by flattening lines and
+ensuring UTF-8 encoding, so downstream code can rely on a consistent format.
 
 For day-to-day work you almost never need to call the constructor directly:
 \code{\link[=read_as_markdown]{read_as_markdown()}} is the recommended way to create a \code{MarkdownDocument}.

--- a/man/MarkdownDocumentChunks.Rd
+++ b/man/MarkdownDocumentChunks.Rd
@@ -18,7 +18,7 @@ also a \code{tibble}.
 Markdown document. It is a tibble with three required columns:
 \itemize{
 \item \code{start}, \code{end} — integers. These are character positions (1-based, inclusive) in the source
-\code{MarkdownDocument}, so that \code{substr(md, start, end)} yields the chunk text.
+\code{MarkdownDocument}, so that \code{substring(md, start, end)} yields the chunk text.
 Ranges can overlap.
 \item \code{context} — character.
 A general-purpose field for adding context to a chunk. This column is

--- a/man/MarkdownDocumentChunks.Rd
+++ b/man/MarkdownDocumentChunks.Rd
@@ -18,8 +18,8 @@ also a \code{tibble}.
 Markdown document. It is a tibble with three required columns:
 \itemize{
 \item \code{start}, \code{end} — integers. These are character positions (1-based, inclusive) in the source
-\code{MarkdownDocument}, so that \code{substring(md, start, end)} yields the chunk text.
-Ranges can overlap.
+\code{MarkdownDocument}, so that \code{substring(md, start, end)} yields the chunk
+text. Ranges can overlap.
 \item \code{context} — character.
 A general-purpose field for adding context to a chunk. This column is
 combined with \code{text} to augment chunk content when generating embeddings with

--- a/man/MarkdownDocumentChunks.Rd
+++ b/man/MarkdownDocumentChunks.Rd
@@ -35,16 +35,21 @@ Additional columns can be included.
 The original document is available via the \verb{@document} property.
 
 For normal use, chunk a Markdown document with \code{\link[=markdown_chunk]{markdown_chunk()}}; the
-class itself is exported only so advanced users can generate or tweak chunks
-by other means.
+class constructor itself is exported only so advanced users can generate or
+tweak chunks by other means.
 }
 \examples{
-doc <- MarkdownDocument("# A\n\nB\n\n## C\n\nD")
+doc_text <- "# A\n\nB\n\n## C\n\nD"
+doc <- MarkdownDocument(doc_text, origin = "some/where")
 chunk_positions <- tibble::tibble(
-  start    = c(1L, 5L),
-  end      = c(3L, 7L),
-  context = c("A", "A\nC")
+  start = c(1L, 9L),
+  end = c(8L, 15L),
+  context = c("", "# A"),
+  text = substring(doc, start, end)
 )
 chunks <- MarkdownDocumentChunks(chunk_positions, doc)
 identical(chunks@document, doc)
+}
+\seealso{
+\code{\link[=MarkdownDocument]{MarkdownDocument()}}
 }

--- a/man/markdown_chunk.Rd
+++ b/man/markdown_chunk.Rd
@@ -10,8 +10,8 @@ markdown_chunk(
   target_overlap = 0.5,
   ...,
   max_snap_dist = target_size * (1 - target_overlap)/3,
-  context = TRUE,
   segment_by_heading_levels = integer(),
+  context = TRUE,
   text = TRUE
 )
 }
@@ -36,9 +36,6 @@ may move to reach a boundary. Defaults to one third of the stride size
 between target chunk starts. Chunks that end up on identical boundaries are
 merged.}
 
-\item{context}{Logical. Add a \code{context} column containing the Markdown
-headings in scope at each chunk start. Default: \code{TRUE}.}
-
 \item{segment_by_heading_levels}{Integer vector with possible values \code{1:6}.
 Headings at these levels are treated as segment boundaries; chunking is
 performed independently for each segment. No chunk will overlap a segment
@@ -46,6 +43,9 @@ boundary, and any future deoverlapping will not combine segments. Each
 segment will have a chunk that starts at the segment start and a chunk that
 starts at the segment end (these may be the same chunk or overlap
 substantially if the segment is short). Default: disabled.}
+
+\item{context}{Logical. Add a \code{context} column containing the Markdown
+headings in scope at each chunk start. Default: \code{TRUE}.}
 
 \item{text}{Logical. If \code{TRUE}, include a \code{text} column with the chunk
 contents. Default: \code{TRUE}.}
@@ -57,11 +57,11 @@ columns \code{start} \code{end}, and optionally \code{context} and \code{text}. 
 normalized and converted to a \code{MarkdownDocument}).
 }
 \description{
-\code{markdown_chunk()} splits a single Markdown string into fixed-length,
+\code{markdown_chunk()} splits a single Markdown string into shorter
 optionally overlapping chunks while nudging cut points to the nearest
 sensible boundary (heading, paragraph, sentence, line, word, or character).
-It returns a tibble recording the character ranges of each chunk and, if
-requested, the heading context and the text itself.
+It returns a tibble recording the character ranges, headings context, and text
+for each chunk.
 }
 \examples{
 md <- "

--- a/man/ragnar_chunk.Rd
+++ b/man/ragnar_chunk.Rd
@@ -53,14 +53,14 @@ strings are \code{unlist()}ed, and dataframes are \code{tidyr::unchop()}ed.}
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
-}
-\details{
+
 These functions are deprecated in favor of \code{markdown_chunk()}, which is more
 flexible, supports overlapping chunks, enables deoverlapping or rechunking
 downstream by \code{ragnar_retrieve()}, and automatically builds a \code{context}
 string of in-scope markdown headings for each chunk instead of requiring
 manual string interpolation from extracted headings.
-
+}
+\details{
 Functions for chunking text into smaller pieces while preserving meaningful
 semantics. These functions provide flexible ways to split text based on
 various boundaries (sentences, words, etc.) while controlling chunk sizes and

--- a/man/ragnar_read.Rd
+++ b/man/ragnar_read.Rd
@@ -35,10 +35,10 @@ order they appear in the markdown content.
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
+
+This function is deprecated in favor of \code{read_as_markdown()}.
 }
 \details{
-This function is deprecated in favor of \code{read_as_markdown()}.
-
 \code{ragnar_read()} uses \href{https://github.com/microsoft/markitdown}{markitdown} to
 convert a document to markdown. If \code{frame_by_tags} or \code{split_by_tags} is
 provided, the converted markdown content is then split and converted to a

--- a/man/ragnar_register_tool_retrieve.Rd
+++ b/man/ragnar_register_tool_retrieve.Rd
@@ -36,7 +36,6 @@ Register a 'retrieve' tool with ellmer
 }
 \examples{
 \dontshow{if ((file.exists("r4ds.ragnar.duckdb") && Sys.getenv("OPENAI_API_KEY") != "")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
-
 system_prompt <- stringr::str_squish("
   You are an expert assistant in R programming.
   When responding, you first quote relevant material from books or documentation,
@@ -44,7 +43,7 @@ system_prompt <- stringr::str_squish("
 ")
 chat <- ellmer::chat_openai(system_prompt, model = "gpt-4o")
 
-store <- ragnar_store_connect("r4ds.ragnar.duckdb", read_only = TRUE)
+store <- ragnar_store_connect("r4ds.ragnar.duckdb")
 ragnar_register_tool_retrieve(chat, store)
 chat$chat("How can I subset a dataframe?")
 \dontshow{\}) # examplesIf}

--- a/man/ragnar_store_create.Rd
+++ b/man/ragnar_store_create.Rd
@@ -122,7 +122,7 @@ store <- ragnar_store_create(
 )
 doc <- MarkdownDocument(paste0(letters, collapse = ""), origin = "/some/where")
 chunks <- markdown_chunk(doc, target_size = 3, target_overlap = 2 / 3)
-chunks$context <- substr(chunks$text, 1, 1)
+chunks$context <- substring(chunks$text, 1, 1)
 chunks
 ragnar_store_insert(store, chunks)
 ragnar_store_build_index(store)

--- a/man/ragnar_store_create.Rd
+++ b/man/ragnar_store_create.Rd
@@ -98,7 +98,7 @@ store <- ragnar_store_create(
 ragnar_store_insert(store, data.frame(text = "hello"))
 
 # A store with a schema. When inserting into this store, users need to
-# provide a `area` column.
+# provide an `area` column.
 store <- ragnar_store_create(
   embed = \(x) matrix(stats::runif(10), nrow = length(x), ncol = 10),
   extra_cols = data.frame(area = character()),
@@ -107,7 +107,7 @@ store <- ragnar_store_create(
 ragnar_store_insert(store, data.frame(text = "hello", area = "rag"))
 
 # If you already have a data.frame with chunks that will be inserted into
-# the store, you can quickly create a suitable store with:
+# the store, you can quickly create a suitable store with `vec_ptype()`:
 chunks <- data.frame(text = letters, area = "rag")
 store <- ragnar_store_create(
   embed = \(x) matrix(stats::runif(10), nrow = length(x), ncol = 10),
@@ -118,14 +118,19 @@ ragnar_store_insert(store, chunks)
 
 # version = 2 (the default) has support for deoverlapping
 store <- ragnar_store_create(
-  embed = NULL # if embed = NULL, then only bm25 search is used (not vss)
+  # if embed = NULL, then only bm25 search is used (not vss)
+  embed = NULL
 )
-doc <- MarkdownDocument(paste0(letters, collapse = ""), origin = "/some/where")
+doc <- MarkdownDocument(
+  paste0(letters, collapse = ""),
+  origin = "/some/where"
+)
 chunks <- markdown_chunk(doc, target_size = 3, target_overlap = 2 / 3)
 chunks$context <- substring(chunks$text, 1, 1)
 chunks
 ragnar_store_insert(store, chunks)
 ragnar_store_build_index(store)
+
 ragnar_retrieve(store, "abc bcd xyz", deoverlap = FALSE)
 ragnar_retrieve(store, "abc bcd xyz", deoverlap = TRUE)
 }

--- a/man/read_as_markdown.Rd
+++ b/man/read_as_markdown.Rd
@@ -60,46 +60,34 @@ and \url{https://facelessuser.github.io/soupsieve/selectors/}
 md <- read_as_markdown("https://r4ds.hadley.nz/base-R.html")
 md
 
-cat(substr(md, 1, 500))
+cat_head <- \(md, n = 10) writeLines(head(strsplit(md, "\n")[[1L]], n))
+cat_head(md)
 
 ## Using selector strings
 
+# By default, this output includes the sidebar and other navigational elements
 url <- "https://duckdb.org/code_of_conduct"
-# Includes the sidebar and other navigational elements
-read_as_markdown(url) |> substr(1, 500) |> writeLines()
+read_as_markdown(url) |> cat_head(15)
 
-# Extract the main content
-read_as_markdown(url, html_extract_selectors = "#main_content_wrap")
+# To extract just the main content, use a selector
+read_as_markdown(url, html_extract_selectors = "#main_content_wrap") |>
+  cat_head()
 
-# Alternative approach: exclude nodes
+# Alternative approach: zap unwanted nodes
 read_as_markdown(
   url,
   html_zap_selectors = c(
-    "header",          # node name
-    ".sidenavigation", # node class
-    ".searchoverlay",  # node class
-    "#sidebar"         # node ID
+    "header",          # name
+    ".sidenavigation", # class
+    ".searchoverlay",  # class
+    "#sidebar"         # ID
   )
-) |> substr(1, 500) |> writeLines()
+) |> cat_head()
 
 # Quarto example
-url <- "https://quarto.org/docs/computations/python.html"
-
-# Include sidebar, footer, etc.
 read_as_markdown(
-  url,
-  html_extract_selectors = NULL,
-  html_zap_selectors = NULL
-) |> substr(1, 500) |> writeLines()
-
-# Exclude content outside <main>
-read_as_markdown(url, html_extract_selectors = "main") |>
-  substr(1, 500) |> writeLines()
-
-# Exclude specific matching nodes
-read_as_markdown(
-  url,
-  html_extract_selectors = NULL,
+  "https://quarto.org/docs/computations/python.html",
+  html_extract_selectors = "main",
   html_zap_selectors = c(
     "#quarto-sidebar",
     "#quarto-margin-sidebar",
@@ -107,13 +95,13 @@ read_as_markdown(
     "footer",
     "nav"
   )
-) |> substr(1, 500) |> writeLines()
+) |> cat_head()
 
-# Convert PDF
+## Convert PDF
 pdf <- file.path(R.home("doc"), "NEWS.pdf")
-read_as_markdown(pdf) |> substr(1, 1000) |> cat()
+read_as_markdown(pdf) |> cat_head(15)
 ## Alternative:
-# pdftools::pdf_text(pdf) |> substr(1, 2000) |> cat()
+# pdftools::pdf_text(pdf) |> cat_head()
 
 # Convert images to markdown descriptions using OpenAI
 jpg <- file.path(R.home("doc"), "html", "logo.jpg")
@@ -121,7 +109,8 @@ if (Sys.getenv("OPENAI_API_KEY") != "") {
   # if (xfun::is_macos()) system("brew install ffmpeg")
   reticulate::py_require("openai")
   llm_client <- reticulate::import("openai")$OpenAI()
-  read_as_markdown(jpg, llm_client = llm_client, llm_model = "gpt-4.1-mini")
+  read_as_markdown(jpg, llm_client = llm_client, llm_model = "gpt-4.1-mini") |>
+    writeLines()
   # # Description:
   # The image displays the logo of the R programming language. It features a
   # large, stylized capital letter "R" in blue, positioned prominently in the

--- a/man/read_as_markdown.Rd
+++ b/man/read_as_markdown.Rd
@@ -12,11 +12,11 @@ read_as_markdown(
 )
 }
 \arguments{
-\item{path}{[string] A filepath or URL. Accepts a wide variety of file types,
-including PDF, PowerPoint, Word, Excel, images (EXIF metadata and OCR),
-audio (EXIF metadata and speech transcription), HTML, text-based formats
-(CSV, JSON, XML), ZIP files (iterates over contents), YouTube URLs, and
-EPUBs.}
+\item{path}{[string] A filepath or URL. Accepts a wide variety of file
+types, including PDF, PowerPoint, Word, Excel, images (EXIF metadata and
+OCR), audio (EXIF metadata and speech transcription), HTML, text-based
+formats (CSV, JSON, XML), ZIP files (iterates over contents), YouTube URLs,
+and EPUBs.}
 
 \item{...}{Passed on to \code{MarkItDown.convert()}.}
 
@@ -36,30 +36,33 @@ A single string of Markdown.
 \description{
 Convert files to Markdown
 }
+\details{
+\subsection{Converting HTML}{
+
+When converting HTML, you might want to omit certain elements, like sidebars,
+headers, footers, etc. You can pass CSS selector strings to either extract
+nodes or exclude nodes during conversion.
+
+The easiest way to make selectors is to use SelectorGadget:
+\url{https://rvest.tidyverse.orgarticles/selectorgadget.html}
+
+You can also right-click on a page and select "Inspect Element" in a browser
+to better understand an HTML page's structure.
+
+For comprehensive or advanced usage of CSS selectors, consult
+\url{https://www.crummy.com/software/BeautifulSoup/bs4/doc/#css-selectors-through-the-css-property}
+and \url{https://facelessuser.github.io/soupsieve/selectors/}
+}
+}
 \examples{
 \dontshow{if (reticulate::py_module_available("markitdown")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 # Convert HTML
-read_as_markdown("https://r4ds.hadley.nz/base-R.html") |>
-  substr(1, 500) |>
-  cat()
+md <- read_as_markdown("https://r4ds.hadley.nz/base-R.html")
+md
 
-read_as_markdown("https://r4ds.hadley.nz/base-R.html", canonical = TRUE) |>
-  substr(1, 500) |>
-  cat()
+cat(substr(md, 1, 500))
 
-# When converting HTML, you might want to omit certain elements, like
-# sidebars, headers, footers, etc. You can pass CSS selector strings
-# to either extract nodes or exclude nodes during conversion.
-#
-# The easiest way to make selectors is to use SelectorGadget:
-# https://rvest.tidyverse.orgarticles/selectorgadget.html
-#
-# You can also right-click on a page and select "Inspect Element" in a
-# browser to better understand an HTML page's structure.
-#
-# For comprehensive or advanced usage of CSS selectors, consult:
-# https://www.crummy.com/software/BeautifulSoup/bs4/doc/#css-selectors-through-the-css-property
-# https://facelessuser.github.io/soupsieve/selectors/
+## Using selector strings
 
 url <- "https://duckdb.org/code_of_conduct"
 # Includes the sidebar and other navigational elements


### PR DESCRIPTION
This PR disables canonicalizing markdown with `commonmark::markdown_commonmark()` in `MarkdownDocument` and `read_as_markdown()`.

The motivation for this is that canonicilization mangles the frontmatter from a Quarto or RMarkdown document.