### PR TITLE
Inspector: make clickable URL's

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # ragnar (development version)
 
+* `ragnar_inspector()` now renders all urls as clickable links in the chunk markdown
+   viewer, even if url is not a formal markdown link (#82).
+
 # ragnar 0.2.0
 
 * `ragnar_store_create()` gains a new argument: `version`, with default `2`.

--- a/inst/store-inspector/modules.R
+++ b/inst/store-inspector/modules.R
@@ -114,6 +114,8 @@ storeInspectorServer <- function(id, store) {
           lapply(function(node) {
             tryCatch(
               {
+                if (xml_name(x) == "a") return()
+
                 text <- as.character(node)
                 text <- stringi::stri_replace_all(
                   text,

--- a/inst/store-inspector/modules.R
+++ b/inst/store-inspector/modules.R
@@ -106,9 +106,35 @@ storeInspectorServer <- function(id, store) {
       }
 
       preview <- if (is.null(preview_type()) || preview_type() == "Preview") {
+        html_preview <- shiny::markdown(selectedDocument()$text) |>
+          xml2::read_html(html_preview)
+
+        html_preview |>
+          xml2::xml_find_all(".//*[not(*)]") |>
+          lapply(function(node) {
+            tryCatch(
+              {
+                text <- as.character(node)
+                text <- stringr::str_replace_all(
+                  text,
+                  "(https?://[^\\s)>\"]+)",
+                  "<a target='_blank' href=\"\\1\">\\1</a>"
+                )
+                xml2::xml_replace(node, xml2::read_xml(text))
+              },
+              error = function(err) {
+                warning(
+                  "Error processing node: ",
+                  conditionMessage(err),
+                  call. = FALSE
+                )
+              }
+            )
+          })
+
         shiny::tags$iframe(
           class = "size-full text-pretty",
-          srcdoc = shiny::markdown(selectedDocument()$text)
+          srcdoc = as.character(html_preview)
         )
       } else {
         shiny::tags$pre(

--- a/inst/store-inspector/modules.R
+++ b/inst/store-inspector/modules.R
@@ -115,7 +115,7 @@ storeInspectorServer <- function(id, store) {
             tryCatch(
               {
                 text <- as.character(node)
-                text <- stringr::str_replace_all(
+                text <- stringi::stri_replace_all(
                   text,
                   "(https?://[^\\s)>\"]+)",
                   "<a target='_blank' href=\"\\1\">\\1</a>"

--- a/inst/store-inspector/modules.R
+++ b/inst/store-inspector/modules.R
@@ -114,7 +114,7 @@ storeInspectorServer <- function(id, store) {
           lapply(function(node) {
             tryCatch(
               {
-                if (xml_name(x) == "a") return()
+                if (xml_name(node) == "a") return()
 
                 text <- as.character(node)
                 text <- stringi::stri_replace_all(


### PR DESCRIPTION
Make urls clickable if they are not correctly rendered when casting markdown to HTML.

Some webpages do insert `<a>` tags inside `<code>` blocks. While this is valid HTML, there's no direct supported Markdown conversion. This PR, converts any URL into a clickable link so the inspector can use it.