### PR TITLE
Support retrieving documents inserted without origin

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,9 @@
 
 * Added `embed_lm_studio` to use LMStudio as an embedding provider (#100).
 
+* Fixed a bug causing `ragnar_retrieve()` to fail when documents were inserted without
+  an origin (#102).
+
 # ragnar 0.2.0
 
 * `ragnar_store_create()` gains a new argument: `version`, with default `2`.

--- a/R/markdown-document.R
+++ b/R/markdown-document.R
@@ -104,7 +104,7 @@ local({
 #' @seealso [MarkdownDocument()]
 #' @name MarkdownDocumentChunks
 #' @examples
-#' doc_text <- "# A\n\nB\n\n## C\n\nD"
+#' doc_text <- "# A\n\nB\n\n## C\n\nD" # can be readLines() output, etc.
 #' doc <- MarkdownDocument(doc_text, origin = "some/where")
 #' chunk_positions <- tibble::tibble(
 #'   start = c(1L, 9L),

--- a/R/retrieve.R
+++ b/R/retrieve.R
@@ -553,13 +553,13 @@ chunks_deoverlap <- function(store, chunks) {
   }
   deoverlapped <- chunks |>
     mutate(embedding = NULL) |>
-    arrange(origin, start) |>
+    arrange(origin, doc_id, start) |>
     mutate(
-      .by = origin,
+      .by = c(origin, doc_id),
       overlap_grp = cumsum(start > lag(end, default = -1L))
     ) |>
     summarize(
-      .by = c(origin, overlap_grp),
+      .by = c(origin, doc_id, overlap_grp),
       origin = first(origin),
       start = first(start),
       end = last(end),
@@ -576,7 +576,7 @@ chunks_deoverlap <- function(store, chunks) {
     "_ragnar_tmp_rechunk",
     deoverlapped |>
       mutate(
-        origin,
+        doc_id,
         start,
         end,
         'deoverlapped_id' = row_number(),
@@ -592,7 +592,7 @@ chunks_deoverlap <- function(store, chunks) {
       doc.text[ rechunked.start: rechunked.end ] AS text
     FROM _ragnar_tmp_rechunk rechunked
     JOIN documents doc
-    USING (origin)
+    USING (doc_id)
     ORDER BY rechunked.deoverlapped_id
     "
   )$text

--- a/man/MarkdownDocumentChunks.Rd
+++ b/man/MarkdownDocumentChunks.Rd
@@ -39,7 +39,7 @@ class constructor itself is exported only so advanced users can generate or
 tweak chunks by other means.
 }
 \examples{
-doc_text <- "# A\n\nB\n\n## C\n\nD"
+doc_text <- "# A\n\nB\n\n## C\n\nD" # can be readLines() output, etc.
 doc <- MarkdownDocument(doc_text, origin = "some/where")
 chunk_positions <- tibble::tibble(
   start = c(1L, 9L),

--- a/tests/testthat/test-retrieve.R
+++ b/tests/testthat/test-retrieve.R
@@ -119,3 +119,32 @@ test_that("retrieving works as expected", {
   ret <- ragnar_retrieve(store, "foo")
   expect_equal(nrow(ret), 3)
 })
+
+test_that("retrieve works when the store contians documents without origin", {
+  skip_on_cran() # See comment (above) in test-retrieve.R
+  skip_if_cant_load_duckdb_extensions()
+
+  store <- ragnar_store_create(embed = NULL)
+
+  doc <- r"(
+  ## Foo
+
+  In id aliquip labore fugiat nulla eu laboris amet id cupidatat sit excepteur officia.
+
+  ## Bar
+
+  Tempor culpa nostrud ipsum pariatur ad sint sit Lorem voluptate ullamco do amet laboris.
+  )"
+
+  chunks <- markdown_chunk(
+    doc,
+    target_size = NA,
+    segment_by_heading_levels = 2
+  )
+
+  ragnar_store_insert(store, chunks)
+  ragnar_store_build_index(store)
+
+  ret <- ragnar_retrieve(store, "laboris")
+  expect_equal(nrow(ret), 2)
+})

--- a/tests/testthat/test-retrieve.R
+++ b/tests/testthat/test-retrieve.R
@@ -124,8 +124,6 @@ test_that("retrieve works when the store contians documents without origin", {
   skip_on_cran() # See comment (above) in test-retrieve.R
   skip_if_cant_load_duckdb_extensions()
 
-  store <- ragnar_store_create(embed = NULL)
-
   doc <- r"(
   ## Foo
 
@@ -136,15 +134,31 @@ test_that("retrieve works when the store contians documents without origin", {
   Tempor culpa nostrud ipsum pariatur ad sint sit Lorem voluptate ullamco do amet laboris.
   )"
 
+  # With this, chunks will not overlap.
   chunks <- markdown_chunk(
     doc,
     target_size = NA,
     segment_by_heading_levels = 2
   )
 
+  store <- ragnar_store_create(embed = NULL)
   ragnar_store_insert(store, chunks)
   ragnar_store_build_index(store)
 
   ret <- ragnar_retrieve(store, "laboris")
   expect_equal(nrow(ret), 2)
+
+  # Also test that deoverlaps works
+  chunks <- markdown_chunk(
+    doc,
+    target_size = 100
+  )
+
+  store <- ragnar_store_create(embed = NULL)
+  ragnar_store_insert(store, chunks)
+  ragnar_store_build_index(store)
+
+  # Expect that all chunks are retrieved and since they overlap they get collapsed.
+  ret <- ragnar_retrieve(store, "laboris")
+  expect_equal(nrow(ret), 1)
 })


### PR DESCRIPTION
DuckDB guarantes that origin is unique if non-null. Switching from `origin` to `doc_id` when joining for deoverlapping should be more robust and allows us to  deoverlap chunks that were inserted without an origin.