### PR TITLE
apply tidy style guide

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -104,7 +104,7 @@ first created, and then automatically called when needed by
 ### 5. Storage
 
 Processed data is stored in a format optimized for efficient searching,
-using the duckdb database system and R implementation in the duckdb package by default. The API is designed to be extensible,
+using [DuckDB](https://duckdb.org).
 allowing additional packages to implement support for different storage
 providers.
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -18,7 +18,7 @@ knitr::opts_chunk$set(
 unlink("r4ds.ragnar.duckdb")
 ```
 
-# ragnar <img src="man/figures/logo.png" align="right" height="138"/>
+# ragnar <a href="https://ragnar.tidyverse.org"><img src="man/figures/logo.png" align="right" height="138" alt="ragnar website" /></a>
 
 <!-- badges: start -->
 
@@ -26,12 +26,12 @@ unlink("r4ds.ragnar.duckdb")
 
 <!-- badges: end -->
 
-`ragnar` is an R package that helps implement Retrieval-Augmented
+ragnar is an R package that helps implement Retrieval-Augmented
 Generation (RAG) workflows. It focuses on providing a complete solution
 with sensible defaults, while still giving the knowledgeable user
 precise control over each step. We don't believe that you can fully
 automate the creation of a good RAG system, so it's important that
-`ragnar` is not a black box. `ragnar` is designed to be transparent. You
+ragnar is not a black box. ragnar is designed to be transparent. You
 can easily inspect outputs at intermediate steps to understand what's
 happening.
 
@@ -54,7 +54,7 @@ pak::pak("tidyverse/ragnar")
 
 ### 1. Document Processing
 
-`ragnar` works with a wide variety of document types, using
+ragnar works with a wide variety of document types, using
 [MarkItDown](https://github.com/microsoft/markitdown) to convert content
 to Markdown.
 
@@ -65,7 +65,7 @@ Key functions:
 
 ### 2. Text Chunking
 
-Next we divide each document into chunks. Ragnar defaults to a strategy
+Next we divide each document into chunks. ragnar defaults to a strategy
 that preserves some of the semantics of the document, but provides
 plenty of opportunities to tweak the approach.
 
@@ -77,7 +77,7 @@ Key functions:
 ### 3. Context Augmentation (Optional)
 
 RAG applications benefit from augmenting text chunks with additional
-context, such as document headings and subheadings. `ragnar` makes it
+context, such as document headings and subheadings. ragnar makes it
 easy to keep track of headings and subheadings as part of chunking.
 
 `markdown_chunk()` automatically associates each chunk with the headings
@@ -85,8 +85,8 @@ that are in scope for that chunk.
 
 ### 4. Embedding
 
-`ragnar` can help compute embeddings for each chunk. The goal is for
-`ragnar` to provide access to embeddings from popular LLM providers.
+ragnar can help compute embeddings for each chunk. The goal is for
+ragnar to provide access to embeddings from popular LLM providers.
 
 Key functions:
 
@@ -104,7 +104,7 @@ first created, and then automatically called when needed by
 ### 5. Storage
 
 Processed data is stored in a format optimized for efficient searching,
-using `duckdb` by default. The API is designed to be extensible,
+using the duckdb database system and R implementation in the duckdb package by default. The API is designed to be extensible,
 allowing additional packages to implement support for different storage
 providers.
 
@@ -131,14 +131,14 @@ Key functions:
 
 ### 7. Chat Augmentation
 
-`ragnar` can equip an `ellmer::Chat` object with a retrieve tool that
+ragnar can equip an `ellmer::Chat` object with a retrieve tool that
 enables an LLM to retrieve content from a store on-demand.
 
 -   `ragnar_register_tool_retrieve(chat, store)`.
 
 ## Usage
 
-Here's an example of using `ragnar` to create a knowledge store from the
+Here's an example of using ragnar to create a knowledge store from the
 *R for Data Science (2e)* book:
 
 ```{r, code = readLines("examples/example-create-store.R")}


### PR DESCRIPTION
unsolicited PR but I was looking at some tidyverse READMEs and found that this one had backticks around R package names. Removed these to comply with the style guide, and no disambiguation was needed.
Also made the html tags for the logo consistent with all other packages in the tidyverse.