### PR TITLE
Abstract the queue from ingest

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -69,4 +69,4 @@ Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.3
 Remotes:  
-    r-lib/mirai@race
+    r-lib/mirai

--- a/R/embed-bedrock.R
+++ b/R/embed-bedrock.R
@@ -50,7 +50,8 @@ embed_bedrock <- function(x, model, profile, api_args = list()) {
   req <- httr2::request(
     paste0("https://bedrock-runtime.", credentials$region, ".amazonaws.com")
   ) |>
-    req_user_agent(ragnar_user_agent())
+    req_user_agent(ragnar_user_agent()) |> 
+    httr2::req_retry(max_tries = 3L)
 
   req <- httr2::req_url_path_append(req, "model", model, "invoke")
   req <- httr2::req_error(req, body = function(resp) {

--- a/R/embed-databricks.R
+++ b/R/embed-databricks.R
@@ -47,6 +47,7 @@ embed_databricks <- function(
     req_url_path_append(
       glue::glue("serving-endpoints/{model}/invocations")
     ) |>
+    httr2::req_retry(max_tries = 3L) |> 
     httr2::req_headers_redacted(!!!credentials()) |>
     httr2::req_user_agent(databricks_user_agent()) |>
     httr2::req_error(body = function(resp) {

--- a/R/embed-gemini.R
+++ b/R/embed-gemini.R
@@ -38,6 +38,7 @@ embed_google_gemini <- function(
 
   base_req <- base_url |>
     httr2::request() |>
+    httr2::req_retry(max_tries = 3L) |> 
     req_user_agent(ragnar_user_agent()) |>
     httr2::req_headers_redacted("x-goog-api-key" = api_key) |>
     httr2::req_url_path_append(

--- a/R/embed-vertex.R
+++ b/R/embed-vertex.R
@@ -61,6 +61,7 @@ embed_google_vertex <- function(
 
   base_req <- vertex_url(location, project_id) |>
     httr2::request() |>
+    httr2::req_retry(max_tries = 3L) |> 
     req_user_agent(ragnar_user_agent()) |>
     httr2::req_headers(!!!credentials, .redact = names(credentials)) |>
     httr2::req_url_path_append(

--- a/R/embed.R
+++ b/R/embed.R
@@ -141,11 +141,18 @@ embed_openai <- function(
     ## max input is 8191 tokens per chunk... what happens if too long?
     data$input <- as.list(text[start:end])
 
+    retries <- 1L
+    openai_after <- function(resp) {
+      time <- as.numeric(httr2::resp_header(resp, "retry-after") %||% 5)
+      retries <<- retries + 1L
+      time * retries
+    }
+
     req <- request(base_url) |>
       req_user_agent(ragnar_user_agent()) |>
       req_url_path_append("/embeddings") |>
       req_auth_bearer_token(api_key) |>
-      req_retry(max_tries = 2L) |>
+      req_retry(max_tries = 3L, after = openai_after) |>
       req_body_json(data) |>
       req_error(body = \(resp) {
         tryCatch(

--- a/R/embed.R
+++ b/R/embed.R
@@ -66,6 +66,7 @@ embed_ollama <- function(
 
   embeddings <- map2(starts, ends, function(start, end) {
     req <- request(base_url) |>
+      httr2::req_retry() |> 
       req_user_agent(ragnar_user_agent()) |>
       req_url_path_append("/api/embed") |>
       req_body_json(list(model = model, input = x[start:end])) |>


### PR DESCRIPTION
- Added a more robust retry logic for openai embedding API
- For other API's the default `httr2::req_retry(max_tries=3)` has been added.
