### PR TITLE
Generalize embed req retry policy

### DIFF
--- a/R/embed-bedrock.R
+++ b/R/embed-bedrock.R
@@ -50,8 +50,8 @@ embed_bedrock <- function(x, model, profile, api_args = list()) {
   req <- httr2::request(
     paste0("https://bedrock-runtime.", credentials$region, ".amazonaws.com")
   ) |>
-    req_user_agent(ragnar_user_agent()) |> 
-    httr2::req_retry(max_tries = 3L)
+    req_user_agent(ragnar_user_agent()) |>
+    embed_req_retry()
 
   req <- httr2::req_url_path_append(req, "model", model, "invoke")
   req <- httr2::req_error(req, body = function(resp) {

--- a/R/embed-databricks.R
+++ b/R/embed-databricks.R
@@ -47,7 +47,7 @@ embed_databricks <- function(
     req_url_path_append(
       glue::glue("serving-endpoints/{model}/invocations")
     ) |>
-    httr2::req_retry(max_tries = 3L) |> 
+    embed_req_retry() |>
     httr2::req_headers_redacted(!!!credentials()) |>
     httr2::req_user_agent(databricks_user_agent()) |>
     httr2::req_error(body = function(resp) {

--- a/R/embed-gemini.R
+++ b/R/embed-gemini.R
@@ -38,7 +38,7 @@ embed_google_gemini <- function(
 
   base_req <- base_url |>
     httr2::request() |>
-    httr2::req_retry(max_tries = 3L) |> 
+    embed_req_retry() |>
     req_user_agent(ragnar_user_agent()) |>
     httr2::req_headers_redacted("x-goog-api-key" = api_key) |>
     httr2::req_url_path_append(

--- a/R/embed-vertex.R
+++ b/R/embed-vertex.R
@@ -61,7 +61,7 @@ embed_google_vertex <- function(
 
   base_req <- vertex_url(location, project_id) |>
     httr2::request() |>
-    httr2::req_retry(max_tries = 3L) |> 
+    embed_req_retry() |>
     req_user_agent(ragnar_user_agent()) |>
     httr2::req_headers(!!!credentials, .redact = names(credentials)) |>
     httr2::req_url_path_append(

--- a/tests/testthat/test-ingest.R
+++ b/tests/testthat/test-ingest.R
@@ -23,7 +23,7 @@ test_that("basic ragnar ingest test", {
     embed = \(x) matrix(runif(100), nrow = 1),
     overwrite = TRUE
   )
-  
+
   expect_error(
     ragnar_store_ingest(store, PATHS, progress = FALSE),
     regexp = 'could not find function "runif"'
@@ -44,5 +44,4 @@ test_that("basic ragnar ingest test", {
   # basic test we have all paths in the store
   n_docs <- dbGetQuery(store@con, "SELECT COUNT(*) as n FROM documents")
   expect_equal(n_docs$n, length(PATHS))
-  
 })


### PR DESCRIPTION
This is a followup to #133 that plumbs through a common approach to applying `req_retry()` policies across all the embed functions.