### PR TITLE
Require mirai 2.5.1 release

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,7 @@ Imports:
     commonmark,
     curl,
     DBI,
-    mirai (>= 2.5.0.9000),
+    mirai (>= 2.5.1),
     dbplyr,
     dplyr,
     duckdb (>= 1.3.1),
@@ -68,5 +68,3 @@ Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.3
-Remotes:  
-    r-lib/mirai


### PR DESCRIPTION
Now that it is on CRAN.